### PR TITLE
Update dm-graindelay.mk

### DIFF
--- a/plugins/package/dm-graindelay/dm-graindelay.mk
+++ b/plugins/package/dm-graindelay/dm-graindelay.mk
@@ -4,7 +4,7 @@
 #
 ######################################
 
-DM_GRAINDELAY_VERSION = 910f0f210a7ac2992d5250952d9bbbd18a5e5962
+DM_GRAINDELAY_VERSION = 710f176fbb087f54c2b756653d4ca32fc7d2c258
 DM_GRAINDELAY_SITE = https://github.com/davemollen/dm-GrainDelay.git
 DM_GRAINDELAY_SITE_METHOD = git
 DM_GRAINDELAY_BUNDLES = dm-GrainDelay.lv2


### PR DESCRIPTION
This new version is a little more performant. 

The following things have also been fixed: 
- Filter cutoff frequency is accurate now
- Feedback at 100% equals unity gain now
- Number of voices is fixed to 4 now