### PR TITLE
Add Ratatouille

### DIFF
--- a/plugins/package/ratatouille/ratatouille.mk
+++ b/plugins/package/ratatouille/ratatouille.mk
@@ -4,7 +4,7 @@
 #
 ######################################
 
-RATATOUILLE_VERSION = a48a8e1a84c0b9f451b2c44177bb8c4c796008ca
+RATATOUILLE_VERSION = 32d87ca068616cc0a65f857be73d86b57f6c6b6d
 RATATOUILLE_SITE = https://github.com/brummer10/Ratatouille.lv2.git
 RATATOUILLE_SITE_METHOD = git
 RATATOUILLE_DEPENDENCIES = libsndfile

--- a/plugins/package/ratatouille/ratatouille.mk
+++ b/plugins/package/ratatouille/ratatouille.mk
@@ -1,0 +1,31 @@
+######################################
+#
+# ratatouille
+#
+######################################
+
+RATATOUILLE_VERSION = a48a8e1a84c0b9f451b2c44177bb8c4c796008ca
+RATATOUILLE_SITE = https://github.com/brummer10/Ratatouille.lv2.git
+RATATOUILLE_SITE_METHOD = git
+RATATOUILLE_DEPENDENCIES = libsndfile
+RATATOUILLE_BUNDLES = Ratatouille.lv2
+
+# needed for submodules support
+RATATOUILLE_PRE_DOWNLOAD_HOOKS += MOD_PLUGIN_BUILDER_DOWNLOAD_WITH_SUBMODULES
+
+RATATOUILLE_SSE_CFLAGS += $(filter-out -funsafe-loop-optimizations,$(subst ",,$(BR2_TARGET_OPTIMIZATION)))
+RATATOUILLE_SSE_CFLAGS += -fno-unsafe-loop-optimizations
+RATATOUILLE_SSE_CFLAGS += -fsingle-precision-constant
+
+RATATOUILLE_TARGET_STRIP = $(HOST_DIR)/usr/bin/$(BR2_TOOLCHAIN_EXTERNAL_CUSTOM_PREFIX)-strip
+RATATOUILLE_TARGET_MAKE = $(TARGET_MAKE_ENV) $(TARGET_CONFIGURE_OPTS) $(MAKE) STRIP=$(RATATOUILLE_TARGET_STRIP) SSE_CFLAGS="$(RATATOUILLE_SSE_CFLAGS)" -C $(@D)
+
+define RATATOUILLE_BUILD_CMDS
+	$(RATATOUILLE_TARGET_MAKE) mod
+endef
+
+define RATATOUILLE_INSTALL_TARGET_CMDS
+	$(RATATOUILLE_TARGET_MAKE) install DESTDIR=$(TARGET_DIR) INSTALL_DIR=/usr/lib/lv2
+endef
+
+$(eval $(generic-package))


### PR DESCRIPTION
A Neural Model loader and mixer. Supports *.nam, *.aidax and *.json based model files.
Ratatouille allow to load up to two model files and mix there output to archive the wanted sound.
The input could be controlled separate for each model.
It provide a delta delay control to overcome possible phasing issues between the models in use. 
Additional it allow to load up to two Impulse Response files and mix them as well.
Ratatouille using parallel processing to process the second slot, that reduce the CPU load.
It provide a additional buffered Mode which introduce a one frame latency 
and moves the complete processing into a background thread, that reduce the CPU load even more. 
