### PR TITLE
Update dm plugins

### DIFF
--- a/plugins/package/dm-ds1/dm-ds1.mk
+++ b/plugins/package/dm-ds1/dm-ds1.mk
@@ -4,7 +4,7 @@
 #
 ######################################
 
-DM_DS1_VERSION = fc9ecdbb755ab5e4b2f6ac799ba353bcf26def53
+DM_DS1_VERSION = 806310991f2461e07aed69f74b962fd4f58c4c2b
 DM_DS1_SITE = https://github.com/davemollen/dm-DS1.git
 DM_DS1_SITE_METHOD = git
 DM_DS1_BUNDLES = dm-DS1.lv2

--- a/plugins/package/dm-fuzz/dm-fuzz.mk
+++ b/plugins/package/dm-fuzz/dm-fuzz.mk
@@ -4,7 +4,7 @@
 #
 ######################################
 
-DM_FUZZ_VERSION = 3f0c5a7e61023aa72ef56b2781a330f1e1e890de
+DM_FUZZ_VERSION = d4d2dcee8a164ac4f69c5d68bb21b4da9ccdfae8
 DM_FUZZ_SITE = https://github.com/davemollen/dm-Fuzz.git
 DM_FUZZ_SITE_METHOD = git
 DM_FUZZ_BUNDLES = dm-Fuzz.lv2

--- a/plugins/package/dm-graindelay/dm-graindelay.mk
+++ b/plugins/package/dm-graindelay/dm-graindelay.mk
@@ -4,7 +4,7 @@
 #
 ######################################
 
-DM_GRAINDELAY_VERSION = 710f176fbb087f54c2b756653d4ca32fc7d2c258
+DM_GRAINDELAY_VERSION = 1cdecb2a739cae20e4499df070de6eef4c8eb35b
 DM_GRAINDELAY_SITE = https://github.com/davemollen/dm-GrainDelay.git
 DM_GRAINDELAY_SITE_METHOD = git
 DM_GRAINDELAY_BUNDLES = dm-GrainDelay.lv2

--- a/plugins/package/dm-lfo/dm-lfo.mk
+++ b/plugins/package/dm-lfo/dm-lfo.mk
@@ -4,7 +4,7 @@
 #
 ######################################
 
-DM_LFO_VERSION = e78bf002aa720d30e5ee9c0794f67fb8f7faea32
+DM_LFO_VERSION = 5c46f4c56a1d00c434c106e50faa0d96daaf741f
 DM_LFO_SITE = https://github.com/davemollen/dm-LFO.git
 DM_LFO_SITE_METHOD = git
 DM_LFO_BUNDLES = dm-LFO.lv2

--- a/plugins/package/dm-rat/dm-rat.mk
+++ b/plugins/package/dm-rat/dm-rat.mk
@@ -4,7 +4,7 @@
 #
 ######################################
 
-DM_RAT_VERSION = f465997d117e888819ef150de4d5f04c8df6343d
+DM_RAT_VERSION = 88be9879a94ade2a2012db185dc1572afe446c05
 DM_RAT_SITE = https://github.com/davemollen/dm-Rat.git
 DM_RAT_SITE_METHOD = git
 DM_RAT_BUNDLES = dm-Rat.lv2

--- a/plugins/package/dm-repeat/dm-repeat.mk
+++ b/plugins/package/dm-repeat/dm-repeat.mk
@@ -4,7 +4,7 @@
 #
 ######################################
 
-DM_REPEAT_VERSION = d1b04d06337f6f1896ae0bb56498ff05b9889c12
+DM_REPEAT_VERSION = ebe7d6f1ea3e0412169e8356a153c7c0e4fb770d
 DM_REPEAT_SITE = https://github.com/davemollen/dm-Repeat.git
 DM_REPEAT_SITE_METHOD = git
 DM_REPEAT_BUNDLES = dm-Repeat.lv2

--- a/plugins/package/dm-reverb/dm-reverb.mk
+++ b/plugins/package/dm-reverb/dm-reverb.mk
@@ -4,7 +4,7 @@
 #
 ######################################
 
-DM_REVERB_VERSION = ea156dd0f7cd497e073e6d0bde3604d1a5de31dd
+DM_REVERB_VERSION = 6d01e3cc8a3bfaf0e74d35783e5f328bdc6be6dc
 DM_REVERB_SITE = https://github.com/davemollen/dm-Reverb.git
 DM_REVERB_SITE_METHOD = git
 DM_REVERB_BUNDLES = dm-Reverb.lv2

--- a/plugins/package/dm-reverse/dm-reverse.mk
+++ b/plugins/package/dm-reverse/dm-reverse.mk
@@ -4,7 +4,7 @@
 #
 ######################################
 
-DM_REVERSE_VERSION = 79dcacf64124018eb42b08b7936578c68523262f
+DM_REVERSE_VERSION = fb11232fb08a6817752b7a0339fb5cd3002a2382
 DM_REVERSE_SITE = https://github.com/davemollen/dm-Reverse.git
 DM_REVERSE_SITE_METHOD = git
 DM_REVERSE_BUNDLES = dm-Reverse.lv2

--- a/plugins/package/dm-sd1/dm-sd1.mk
+++ b/plugins/package/dm-sd1/dm-sd1.mk
@@ -4,7 +4,7 @@
 #
 ######################################
 
-DM_SD1_VERSION = 1afa503f81a0b8f834e481dc2c4acb7726a0b4d5
+DM_SD1_VERSION = 385ae026891224fa4e815bc83c381c1e528cd216
 DM_SD1_SITE = https://github.com/davemollen/dm-SD1.git
 DM_SD1_SITE_METHOD = git
 DM_SD1_BUNDLES = dm-SD1.lv2

--- a/plugins/package/dm-shredmaster/dm-shredmaster.mk
+++ b/plugins/package/dm-shredmaster/dm-shredmaster.mk
@@ -4,7 +4,7 @@
 #
 ######################################
 
-DM_SHREDMASTER_VERSION = 9e48c36ed75556c59535694284b7c6a620a79070
+DM_SHREDMASTER_VERSION = d9db3aa0f3924825e97f1434daa597040228d716
 DM_SHREDMASTER_SITE = https://github.com/davemollen/dm-Shredmaster.git
 DM_SHREDMASTER_SITE_METHOD = git
 DM_SHREDMASTER_BUNDLES = dm-Shredmaster.lv2

--- a/plugins/package/dm-spaceecho/dm-spaceecho.mk
+++ b/plugins/package/dm-spaceecho/dm-spaceecho.mk
@@ -4,7 +4,7 @@
 #
 ######################################
 
-DM_SPACEECHO_VERSION = 7366a27612a64b2bf465e408e5a6fdc6b24b7e2c
+DM_SPACEECHO_VERSION = 2f2373601ec5480c234aa07ad8d4ca90debad3b2
 DM_SPACEECHO_SITE = https://github.com/davemollen/dm-SpaceEcho.git
 DM_SPACEECHO_SITE_METHOD = git
 DM_SPACEECHO_BUNDLES = dm-SpaceEcho.lv2

--- a/plugins/package/dm-stutter/dm-stutter.mk
+++ b/plugins/package/dm-stutter/dm-stutter.mk
@@ -4,7 +4,7 @@
 #
 ######################################
 
-DM_STUTTER_VERSION = e352ade19bdb2b6b66e277fdc0879d4e1a341946
+DM_STUTTER_VERSION = a2ce93bf9b36848c111c079a5e30382bc75f088c
 DM_STUTTER_SITE = https://github.com/davemollen/dm-Stutter.git
 DM_STUTTER_SITE_METHOD = git
 DM_STUTTER_BUNDLES = dm-Stutter.lv2

--- a/plugins/package/dm-tubescreamer/dm-tubescreamer.mk
+++ b/plugins/package/dm-tubescreamer/dm-tubescreamer.mk
@@ -4,7 +4,7 @@
 #
 ######################################
 
-DM_TUBESCREAMER_VERSION = 6a2f3f0b0b8f3e867bd483875439b41ae31a6600
+DM_TUBESCREAMER_VERSION = 777e6f6129d35cafb2a2a79e277d177351565e7b
 DM_TUBESCREAMER_SITE = https://github.com/davemollen/dm-TubeScreamer.git
 DM_TUBESCREAMER_SITE_METHOD = git
 DM_TUBESCREAMER_BUNDLES = dm-TubeScreamer.lv2

--- a/plugins/package/dm-vibrato/dm-vibrato.mk
+++ b/plugins/package/dm-vibrato/dm-vibrato.mk
@@ -4,7 +4,7 @@
 #
 ######################################
 
-DM_VIBRATO_VERSION = c5b1445681168ffe49d8081543dd2ab40e3c0289
+DM_VIBRATO_VERSION = 47b2454afe37cf7d85f079e911fcbec433fc0b8d
 DM_VIBRATO_SITE = https://github.com/davemollen/dm-Vibrato.git
 DM_VIBRATO_SITE_METHOD = git
 DM_VIBRATO_BUNDLES = dm-Vibrato.lv2

--- a/plugins/package/dm-whammy/dm-whammy.mk
+++ b/plugins/package/dm-whammy/dm-whammy.mk
@@ -4,7 +4,7 @@
 #
 ######################################
 
-DM_WHAMMY_VERSION = 76fa750a16bf07a1ed6e551736a138bbabbe067c
+DM_WHAMMY_VERSION = 3d2047fb7cfcedb69de3bfcb6261af4e0ffef917
 DM_WHAMMY_SITE = https://github.com/davemollen/dm-Whammy.git
 DM_WHAMMY_SITE_METHOD = git
 DM_WHAMMY_BUNDLES = dm-Whammy.lv2


### PR DESCRIPTION
I expect Rust will need to be updated (`rustup update`) on the builder to get this PR build to work. Because on the Cloud builder I get `lock file version `4` was found, but this version of Cargo does not understand this lock file, perhaps Cargo needs to be updated?`.

All my plugins can be built on macOS now too. So these could technically be ported to Mod Desktop now.
I have an example of how I got a macOS desktop build working here: https://github.com/davemollen/dm-SpaceEcho/blob/feature/mod-desktop-build/scripts/build-lv2-for-mod-desktop-mac.sh.

Changes are:
- dm-Stutter: new Mix parameter
- dm-Stutter: all note length sliders at 0% gives an even note length distribution
- dm-GrainDelay: Drift parameter works properly now
- dm-GrainDelay: bugfix for no sound with Pitch at 0st and Drift at >0%
- dm-Vibrato: updated default values
- Param smoothing implementation was updated for all plugins.
